### PR TITLE
Update libtomo.cpp

### DIFF
--- a/longitudinal_tomography/cpp_routines/libtomo.cpp
+++ b/longitudinal_tomography/cpp_routines/libtomo.cpp
@@ -345,7 +345,7 @@ d_array wrapper_project(
 
     project(flat_rec, flat_points, weights, n_particles, n_profiles);
 
-    buffer_flat_rec.shape = std::vector<ssize_t>{n_profiles, n_bins};
+    buffer_flat_rec.shape = std::vector<py::ssize_t>{n_profiles, n_bins};
 
     return input_flat_rec;
 }


### PR DESCRIPTION
windows compilation bugfix

`ssize_t` is not available under windows and thus crashes the installation process during the compiletime. 